### PR TITLE
Allow save_neighbors = FALSE

### DIFF
--- a/R/largeVis.R
+++ b/R/largeVis.R
@@ -121,7 +121,6 @@ largeVis <- function(x,
   #######################################################
 
   returnvalue <- list(
-    knns = t(knns),
     wij = wij,
     call = sys.call(),
     coords = coords


### PR DESCRIPTION
Extremely small bug fix that should avoid an error I'm getting.

If `save_neighbors == FALSE`, the current code for `largeVis` attempts to transpose the matrix `knns` after it's been removed, raising an error. Removing this line fixes that error, and makes the code behave the same as for the parameter `save_edges`.